### PR TITLE
Update install.sh

### DIFF
--- a/2chproxy.pl
+++ b/2chproxy.pl
@@ -65,7 +65,7 @@ my $PROXY_CONFIG  = {
   LISTEN_PORT => 8080,                                #listenするポート
   FORWARD_PROXY => '',                                #上位プロクシがあれば"http://host:port/"みたいに書く
   MAXIMUM_CONNECTIONS => 20,                          #最大同時接続数
-  USER_AGENT => 'Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0',
+  USER_AGENT => 'Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0',
                                                       #UA偽装
   ENABLE_WEB_SCRAPING => 1,                           #datへのアクセスの際にWEBスクレイピングを有効にする
                                                       #datへの直アクセスが禁止されない限りは有効にしない方がいい

--- a/README.md
+++ b/README.md
@@ -28,15 +28,28 @@ ubuntu14.04LTS の場合。
 
 すれば更新されます。
 
-# インストール(JDユーザー向け)
+# インストール(JDimユーザー向け)
 
 　作成されたディレクトリ、 _2chproxy.pl/_ に移動し、
 
 `   ./install.sh`
 
-すれば自動でインストールからJDの設定までしてくれます。
+すれば自動でインストールからJDimの設定までしてくれます。
 
-あとはリログし、JDのアイコンをクリックするだけです。
+- `./install.sh`の第1引数で`2chproxy.pl`のインストール場所を変更できます。（省略した場合は _$HOME/bin_）
+  ```sh
+  # 例
+  ./install.sh "$HOME/.local/bin"
+  # => $HOME/.local/bin/2chproxy.pl, $HOME/.local/bin/jd.sh
+  ```
+- `./install.sh`の第2引数でJDimの実行ファイルを指定できます（省略した場合はPATHからjdimを探す）。
+  実行ファイルが見つからない場合インストールは実行されません。
+  ```sh
+  # 例
+  ./install.sh "$HOME/bin" "/usr/local/bin/jdim"
+  ```
+
+あとはリログし、JDimのアイコンをクリックするだけです。
 
 # 設定
 
@@ -94,7 +107,7 @@ ubuntu14.04LTS の場合。
 
 　また場合によっては高度な設定で 2chにアクセスするときのエージェント名や、2chのクッキーを見直す。
 
-　ディストリ提供のJDがsegfaultで起動しない場合は [こちら](https://github.com/yama-natuki/JD/tree/test) を試してみてください。
+　ディストリ提供のJDがsegfaultで起動しない場合は [こちら](https://github.com/JDimproved/JDim) を試してみてください。
 
 # 変更点
 


### PR DESCRIPTION
インストールスクリプトをjdim向けに更新します。

#### 変更点
- スクリプトの第2引数で実行ファイルの場所を指定できる、省略したときはPATHから探す
- `jd.conf` の場所は実行ファイルと `~/.jd` を調べて決定する

#### 制限
- 環境変数`JDIM_CACHE`によるキャッシュディレクトリの変更は考慮しない
