### PR TITLE
URL置換で順序を保存するように

### DIFF
--- a/2chproxy.pl
+++ b/2chproxy.pl
@@ -516,10 +516,7 @@ sub html2dat() {
         elsif ($PROXY_CONFIG->{ENABLE_2CH_TO_nCH} == 4) {
           $url =~ s|\d+ch\.net|2ch.net|;
         }
-        $replace_url_list{$url} = 1;
-      }
-      foreach my $url (keys(%replace_url_list)) {
-        $var{content} .= "<br> [Replace URL] $url ";
+        $var{content} .= "<br> [Replace URL] $url " unless $replace_url_list{$url}++;
       }
     }
 


### PR DESCRIPTION
Navi2ch であぼーん判定されることが多く、URL置換で末尾に追加される順番がランダムなのが原因のような気がしたので、順番を保持するようにしてみました。